### PR TITLE
Ensure DB connection closes after drop

### DIFF
--- a/etl/drop_epwa_detailed_flights.py
+++ b/etl/drop_epwa_detailed_flights.py
@@ -15,3 +15,5 @@ try:
 except Exception as e:
     print(f"❌ Error while dropping the table: {e}")
     raise
+finally:
+    conn.close()


### PR DESCRIPTION
## Summary
- always close the DuckDB connection when dropping `epwa_detailed_flights`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a80867df8832f86952757bcef789c