### PR TITLE
Fix README project structure root name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can set up the entire environment automatically on a fresh Ubuntu machine.
 ## 📁 Project Structure
 
 ```
-project_epwa_daily_traffic/
+epwa-flight-etl/
 ├── airflow/                      # Airflow DAGs and configuration
 ├── data/
 │   ├── raw/                      # Raw JSONs from Aviationstack API


### PR DESCRIPTION
## Summary
- fix repo root name in project structure diagram

## Testing
- `python -m py_compile $(find . -name '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a8093ffb0832f89e210d482a6caad