### PR TITLE
Add script for automatic repo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,19 @@ airflow scheduler
 airflow webserver
 ```
 
+
+---
+
+## \ud83d\udc04 Updating the Project
+
+Use the `update_project.sh` script to keep your local repository in sync with GitHub. The script checks for new commits on the tracked remote branch and pulls them if available.
+
+```bash
+./update_project.sh
+```
+
+You can add this script to a cron job or run it manually whenever you want to ensure you have the latest version.
+
 ---
 
 ## 📄 License

--- a/update_project.sh
+++ b/update_project.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Script to update repository when new commits appear on GitHub
+
+# Make sure we run in repository root
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$REPO_DIR"
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "This directory is not a git repository." >&2
+    exit 1
+fi
+
+if [ -z "$(git remote)" ]; then
+    echo "No git remote configured." >&2
+    exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "Uncommitted changes found. Please commit or stash them before updating." >&2
+    exit 1
+fi
+
+# Fetch remote updates
+git remote update
+
+LOCAL=$(git rev-parse @)
+REMOTE=$(git rev-parse @{u})
+
+if [ "$LOCAL" != "$REMOTE" ]; then
+    echo "Remote changes detected. Pulling latest version..."
+    git pull --ff-only
+else
+    echo "Repository is already up-to-date."
+fi


### PR DESCRIPTION
## Summary
- add `update_project.sh` to automatically update repo from remote
- document update script in README

## Testing
- `python -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_684aa64de248832fa1e9bd8e51180193