### PR TITLE
Add Airflow health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ You can set up the entire environment automatically on a fresh Ubuntu machine.
    - **Username:** `admin`
    - **Password:** `StrongPassword123`
 
+   If the page does not load, run the health check:
+   ```bash
+   ./check_airflow.sh <your-vm-ip>
+   ```
+   This script verifies the Airflow webserver is running and reachable.
+
 ---
 
 ## 📁 Project Structure

--- a/check_airflow.sh
+++ b/check_airflow.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple health check for Airflow webserver on port 8080
+# Usage: ./check_airflow.sh [host]
+# If no host is provided, localhost is used.
+
+HOST=${1:-localhost}
+PORT=8080
+
+if command -v pgrep >/dev/null; then
+  echo "Checking if Airflow webserver process is running..."
+  if pgrep -f "airflow webserver" >/dev/null; then
+    echo "Airflow webserver process is running."
+  else
+    echo "Airflow webserver process not found." >&2
+    exit 1
+  fi
+fi
+
+echo "Checking if port $PORT is listening..."
+python3 - <<PY
+import socket,sys
+s=socket.socket()
+try:
+    s.settimeout(2)
+    s.connect(("localhost", $PORT))
+    print("Port $PORT is open.")
+except Exception as e:
+    print("Port $PORT is not open.", file=sys.stderr)
+    sys.exit(1)
+finally:
+    s.close()
+PY
+
+echo "Checking HTTP response from http://$HOST:$PORT ..."
+python3 - <<PY
+import sys
+from urllib import request, error
+url = "http://$HOST:$PORT"
+try:
+    with request.urlopen(url, timeout=5) as resp:
+        print(f"Received {resp.status} from {url}")
+except Exception as e:
+    print(f"Failed to reach {url}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+exit 0


### PR DESCRIPTION
## Summary
- add `check_airflow.sh` helper to verify Airflow is running on port 8080
- document how to use the script in the quick start instructions

## Testing
- `./check_airflow.sh localhost` *(fails: Airflow not running)*

------
https://chatgpt.com/codex/tasks/task_e_684aaa06645c832fa3ddb89df9af3f53