### PR TITLE
Add instructional output for update script

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Use the `update_project.sh` script to keep your local repository in sync with Gi
 ./update_project.sh
 ```
 
+If the update cannot proceed (e.g., due to uncommitted changes or a missing remote),
+the script explains how to fix the issue before re-running.
+
 You can add this script to a cron job or run it manually whenever you want to ensure you have the latest version.
 
 ---

--- a/update_project.sh
+++ b/update_project.sh
@@ -8,17 +8,37 @@ REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_DIR"
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    echo "This directory is not a git repository." >&2
+    cat >&2 <<'EOF'
+This directory is not a git repository.
+Clone the project with:
+    git clone https://github.com/mkonefal2/epwa-flight-etl.git
+or navigate to your existing clone and re-run this script.
+EOF
     exit 1
 fi
 
 if [ -z "$(git remote)" ]; then
-    echo "No git remote configured." >&2
+    cat >&2 <<'EOF'
+No git remote configured.
+Connect your repository to a remote with:
+    git remote add origin <url>
+Then run this script again to pull updates.
+EOF
     exit 1
 fi
 
 if [ -n "$(git status --porcelain)" ]; then
-    echo "Uncommitted changes found. Please commit or stash them before updating." >&2
+    cat >&2 <<'EOF'
+Uncommitted changes found.
+View them with:
+    git status
+Commit your changes:
+    git add <files>
+    git commit -m "Your message"
+Or stash them temporarily:
+    git stash
+Afterward, re-run this script.
+EOF
     exit 1
 fi
 
@@ -31,6 +51,7 @@ REMOTE=$(git rev-parse @{u})
 if [ "$LOCAL" != "$REMOTE" ]; then
     echo "Remote changes detected. Pulling latest version..."
     git pull --ff-only
+    echo "Update complete."
 else
     echo "Repository is already up-to-date."
 fi


### PR DESCRIPTION
## Summary
- provide guided instructions in `update_project.sh` when encountering typical issues
- mention that the script explains how to resolve problems in README

## Testing
- `./update_project.sh`

------
https://chatgpt.com/codex/tasks/task_e_684aab41050c832fab816e3227ec5aa1