### PR TITLE
Place project under airflow home

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ You can set up the entire environment automatically on a fresh Ubuntu machine.
    chmod +x install_and_start.sh
    sudo ./install_and_start.sh
    ```
-   The script detects any previous installation in `/home/airflow/epwa-flight-etl`
-   and offers to remove it for a clean reinstall.
+   The script installs the project into `/home/airflow/epwa-flight-etl`, ensuring
+   ownership by the `airflow` user. If an installation already exists there, it
+   offers to remove it for a clean reinstall.
 
 3. After the script finishes, open:
    ```
@@ -43,6 +44,9 @@ You can set up the entire environment automatically on a fresh Ubuntu machine.
    ```bash
    ./restart_webserver.sh
    ```
+   The script assumes the project resides in `/home/airflow/epwa-flight-etl`
+   and starts the webserver on port `8080` in the background, writing logs to
+   `airflow/webserver.log`.
 
 ---
 

--- a/restart_webserver.sh
+++ b/restart_webserver.sh
@@ -4,26 +4,34 @@ set -euo pipefail
 # Restart the Airflow webserver
 # Requires privileges to manage the airflow user processes
 
-REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="/home/airflow/epwa-flight-etl"
 AIRFLOW_HOME="$REPO_DIR/airflow"
 AIRFLOW_USER="airflow"
 AIRFLOW_CMD="$REPO_DIR/venv/bin/airflow"
+LOG_FILE="$AIRFLOW_HOME/webserver.log"
 
 stop_webserver() {
     echo "Stopping Airflow webserver if running..."
     pkill -u "$AIRFLOW_USER" -f "airflow webserver" >/dev/null 2>&1 || true
 }
 
-start_webserver() {
-    echo "Starting Airflow webserver..."
+ensure_permissions() {
     if [ "$(id -u)" -eq 0 ]; then
-        sudo -u "$AIRFLOW_USER" bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && nohup $AIRFLOW_CMD webserver -p 8080 > $AIRFLOW_HOME/webserver.log 2>&1 &"
-    else
-        export AIRFLOW_HOME="$AIRFLOW_HOME"
-        nohup "$AIRFLOW_CMD" webserver -p 8080 > "$AIRFLOW_HOME/webserver.log" 2>&1 &
+        chown -R "$AIRFLOW_USER:$AIRFLOW_USER" "$REPO_DIR"
     fi
 }
 
+start_webserver() {
+    echo "Starting Airflow webserver..."
+    if [ "$(id -u)" -eq 0 ]; then
+        sudo -u "$AIRFLOW_USER" bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && nohup $AIRFLOW_CMD webserver -p 8080 > $LOG_FILE 2>&1 &"
+    else
+        export AIRFLOW_HOME="$AIRFLOW_HOME"
+        nohup "$AIRFLOW_CMD" webserver -p 8080 > "$LOG_FILE" 2>&1 &
+    fi
+}
+
+ensure_permissions
 stop_webserver
 start_webserver
 


### PR DESCRIPTION
## Summary
- ensure the restart script works from `/home/airflow/epwa-flight-etl`
- clarify installer notes in README
- document how the restart script runs the webserver

## Testing
- `bash -n restart_webserver.sh`
- `bash -n install_and_start.sh`


------
https://chatgpt.com/codex/tasks/task_e_684ab828385c832faa83faa08d04a913