### PR TITLE
Fix Airflow paths after move

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Replace the placeholder in `etl/extract.py` with your key.
 
 ```bash
 python -m venv venv
-source venv/bin/activate
+. venv/bin/activate
 pip install -r requirements.txt
 
 python etl/extract.py

--- a/airflow/dags/backup_epwa_detailed_flights.py
+++ b/airflow/dags/backup_epwa_detailed_flights.py
@@ -27,5 +27,5 @@ with DAG(
 
     backup_task = BashOperator(
         task_id="backup_epwa_detailed_flights",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python backup_epwa_detailed_flights.py",  
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python backup_epwa_detailed_flights.py",
     )

--- a/airflow/dags/drop_epwa_detailed_flights.py
+++ b/airflow/dags/drop_epwa_detailed_flights.py
@@ -27,5 +27,5 @@ with DAG(
 
     drop_task = BashOperator(
         task_id="drop_epwa_detailed_flights_table",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python drop_epwa_detailed_flights.py",    
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python drop_epwa_detailed_flights.py",
     )

--- a/airflow/dags/enrich_epwa_country_detailed_flights.py
+++ b/airflow/dags/enrich_epwa_country_detailed_flights.py
@@ -27,5 +27,5 @@ with DAG(
 
     enrich_arrival_country = BashOperator(
         task_id="enrich_arrival_country",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python enrich_epwa_country_detailed_flights.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python enrich_epwa_country_detailed_flights.py",
     )

--- a/airflow/dags/flights_pipeline.py
+++ b/airflow/dags/flights_pipeline.py
@@ -27,32 +27,32 @@ with DAG(
 
     extract_task = BashOperator(
         task_id="extract_from_api",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python extract.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python extract.py",
     )
 
     transform_daily_traffic = BashOperator(
         task_id="transform_daily_traffic",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python transform_daily_traffic.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python transform_daily_traffic.py",
     )
 
     transform_detailed_flights = BashOperator(
         task_id="transform_detailed_flights",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python transform_detailed_scheduled_date.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python transform_detailed_scheduled_date.py",
     )
 
     load_daily_traffic = BashOperator(
         task_id="load_daily_traffic",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python load_epwa_daily_traffic.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python load_epwa_daily_traffic.py",
     )
 
     load_detailed_flights = BashOperator(
         task_id="load_detailed_flights",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python load_epwa_detailed_flights.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python load_epwa_detailed_flights.py",
     )
 
     enrich_arrival_country = BashOperator(
         task_id="enrich_arrival_country",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python enrich_epwa_country_detailed_flights.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python enrich_epwa_country_detailed_flights.py",
     )
 
     extract_task >> [transform_daily_traffic, transform_detailed_flights]

--- a/airflow/dags/transform_load.py
+++ b/airflow/dags/transform_load.py
@@ -27,12 +27,12 @@ with DAG(
 
     transform_task = BashOperator(
         task_id="transform_detailed_flights",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python transform_detailed_scheduled_date.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python transform_detailed_scheduled_date.py",
     )
 
     load_task = BashOperator(
         task_id="load_detailed_flights",
-        bash_command=f"cd {etl_dir} && source ../venv/bin/activate && python load_epwa_detailed_flights.py",
+        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python load_epwa_detailed_flights.py",
     )
 
     transform_task >> load_task

--- a/install_and_start.sh
+++ b/install_and_start.sh
@@ -52,13 +52,19 @@ fi
 
 export AIRFLOW_HOME="$REPO_DIR/airflow"
 
+# persist AIRFLOW_HOME for the airflow user
+if [ -f /home/airflow/.bashrc ] && ! grep -q "AIRFLOW_HOME" /home/airflow/.bashrc; then
+    echo "export AIRFLOW_HOME=$AIRFLOW_HOME" >> /home/airflow/.bashrc
+    chown airflow:airflow /home/airflow/.bashrc
+fi
+
 sudo -u airflow bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && $REPO_DIR/venv/bin/airflow db init"
 
 sudo -u airflow bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && $REPO_DIR/venv/bin/airflow users create --username admin --password StrongPassword123 --firstname Admin --lastname User --role Admin --email admin@example.com || true"
 
 sudo -u airflow bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && nohup $REPO_DIR/venv/bin/airflow scheduler > $AIRFLOW_HOME/scheduler.log 2>&1 &"
 
-sudo -u airflow bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && nohup $REPO_DIR/venv/bin/airflow webserver -p 8080 > $AIRFLOW_HOME/webserver.log 2>&1 &"
+sudo -u airflow bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && nohup $REPO_DIR/venv/bin/airflow webserver --port 8080 --debug > $AIRFLOW_HOME/webserver.log 2>&1 &"
 
 cat <<EOM
 Airflow is running in the background.

--- a/restart_webserver.sh
+++ b/restart_webserver.sh
@@ -24,10 +24,10 @@ ensure_permissions() {
 start_webserver() {
     echo "Starting Airflow webserver..."
     if [ "$(id -u)" -eq 0 ]; then
-        sudo -u "$AIRFLOW_USER" bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && nohup $AIRFLOW_CMD webserver -p 8080 > $LOG_FILE 2>&1 &"
+        sudo -u "$AIRFLOW_USER" bash -c "export AIRFLOW_HOME=$AIRFLOW_HOME && nohup $AIRFLOW_CMD webserver --port 8080 --debug > $LOG_FILE 2>&1 &"
     else
         export AIRFLOW_HOME="$AIRFLOW_HOME"
-        nohup "$AIRFLOW_CMD" webserver -p 8080 > "$LOG_FILE" 2>&1 &
+        nohup "$AIRFLOW_CMD" webserver --port 8080 --debug > "$LOG_FILE" 2>&1 &
     fi
 }
 


### PR DESCRIPTION
## Summary
- persist `AIRFLOW_HOME` in `install_and_start.sh`
- start the webserver in debug mode
- replace `source` with `.` for POSIX sh compatibility

## Testing
- `bash -n install_and_start.sh`
- `bash -n restart_webserver.sh`
- `bash check_airflow.sh localhost` *(fails: Airflow webserver process not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac0faad5c832fbb0c7f3a7f323df4