### PR TITLE
Add DAG update helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ notebooks/
 tests/
 # Ignore scripts
 scripts/
+!scripts/
+!scripts/update_dags.sh
 # Ignore Docker files
 docker-compose.yml
 Dockerfile

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ the script explains how to fix the issue before re-running.
 
 You can add this script to a cron job or run it manually whenever you want to ensure you have the latest version.
 
+To update only the DAG definitions without touching other files, run:
+
+```bash
+./scripts/update_dags.sh
+```
+This pulls the latest code and reloads the Airflow scheduler so new DAGs are picked up.
+
 ---
 
 ## 📄 License

--- a/scripts/update_dags.sh
+++ b/scripts/update_dags.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update Airflow DAGs from the git repository and reload the scheduler
+
+# Determine repository root (one level up from this script)
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+# Pull latest changes (fast-forward only)
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    git pull --ff-only
+else
+    echo "Error: $REPO_DIR is not a git repository" >&2
+    exit 1
+fi
+
+# Signal Airflow scheduler to reload DAGs
+pkill -HUP -f "airflow scheduler" >/dev/null 2>&1 || true
+
+echo "DAGs updated and scheduler reloaded."


### PR DESCRIPTION
## Summary
- add `update_dags.sh` helper for pulling DAGs and reloading scheduler
- allow tracking scripts directory for the new helper
- document DAG update workflow in README

## Testing
- `bash -n scripts/update_dags.sh`


------
https://chatgpt.com/codex/tasks/task_e_684ad616b400832fb3953eac30f005ea