### PR TITLE
Switch DAGs to PythonOperator

### DIFF
--- a/airflow/dags/backup_epwa_detailed_flights.py
+++ b/airflow/dags/backup_epwa_detailed_flights.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -25,7 +25,8 @@ with DAG(
     tags=["epwa", "backup"],
 ) as dag:
 
-    backup_task = BashOperator(
+    backup_task = PythonOperator(
         task_id="backup_epwa_detailed_flights",
-        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python backup_epwa_detailed_flights.py",
+        python_callable=lambda: __import__("etl.backup_epwa_detailed_flights").backup_epwa_detailed_flights.main(),
     )
+

--- a/airflow/dags/drop_epwa_detailed_flights.py
+++ b/airflow/dags/drop_epwa_detailed_flights.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -25,7 +25,8 @@ with DAG(
     tags=["epwa", "drop", "maintenance"],
 ) as dag:
 
-    drop_task = BashOperator(
+    drop_task = PythonOperator(
         task_id="drop_epwa_detailed_flights_table",
-        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python drop_epwa_detailed_flights.py",
+        python_callable=lambda: __import__("etl.drop_epwa_detailed_flights").drop_epwa_detailed_flights.main(),
     )
+

--- a/airflow/dags/enrich_epwa_country_detailed_flights.py
+++ b/airflow/dags/enrich_epwa_country_detailed_flights.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -25,7 +25,8 @@ with DAG(
     tags=["epwa", "enrichment"],
 ) as dag:
 
-    enrich_arrival_country = BashOperator(
+    enrich_arrival_country = PythonOperator(
         task_id="enrich_arrival_country",
-        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python enrich_epwa_country_detailed_flights.py",
+        python_callable=lambda: __import__("etl.enrich_epwa_country_detailed_flights").enrich_epwa_country_detailed_flights.main(),
     )
+

--- a/airflow/dags/transform_load.py
+++ b/airflow/dags/transform_load.py
@@ -1,5 +1,5 @@
 from airflow import DAG
-from airflow.operators.bash import BashOperator
+from airflow.operators.python import PythonOperator
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -25,14 +25,15 @@ with DAG(
     tags=["epwa", "manual", "transform", "load"],
 ) as dag:
 
-    transform_task = BashOperator(
+    transform_task = PythonOperator(
         task_id="transform_detailed_flights",
-        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python transform_detailed_scheduled_date.py",
+        python_callable=lambda: __import__("etl.transform_detailed_scheduled_date").transform_detailed_scheduled_date.main(),
     )
 
-    load_task = BashOperator(
+    load_task = PythonOperator(
         task_id="load_detailed_flights",
-        bash_command=f"cd {etl_dir} && . ../venv/bin/activate && python load_epwa_detailed_flights.py",
+        python_callable=lambda: __import__("etl.load_epwa_detailed_flights").load_epwa_detailed_flights.main(),
     )
 
     transform_task >> load_task
+

--- a/etl/backup_epwa_detailed_flights.py
+++ b/etl/backup_epwa_detailed_flights.py
@@ -3,38 +3,40 @@ from datetime import datetime
 from pathlib import Path
 import sys
 
-# Path to the database
-project_root = Path(__file__).resolve().parents[1]
-db_path = project_root / "db" / "epwa_traffic.duckdb"
 
-# Backup name with the current date
-today_str = datetime.today().strftime("%Y_%m_%d")
-backup_table = f"epwa_detailed_flights_backup_{today_str}"
+def main():
+    """Create a dated backup of the detailed flights table."""
+    project_root = Path(__file__).resolve().parents[1]
+    db_path = project_root / "db" / "epwa_traffic.duckdb"
 
-# Connection
-conn = duckdb.connect(str(db_path))
+    today_str = datetime.today().strftime("%Y_%m_%d")
+    backup_table = f"epwa_detailed_flights_backup_{today_str}"
 
-# Check if the backup already exists
-tables = conn.execute("SHOW TABLES").fetchall()
-table_names = [t[0] for t in tables]
+    conn = duckdb.connect(str(db_path))
 
-if backup_table in table_names:
-    print(f"⚠️ Backup {backup_table} already exists. Skipping creation.")
-else:
-    print(f"🛠 Creating backup: {backup_table}")
-    conn.execute(f"CREATE TABLE {backup_table} AS SELECT * FROM epwa_detailed_flights")
+    tables = conn.execute("SHOW TABLES").fetchall()
+    table_names = [t[0] for t in tables]
 
-# Validation: check if the table exists and contains data
-try:
-    result = conn.execute(f"SELECT COUNT(*) FROM {backup_table}").fetchone()
-    row_count = result[0]
-
-    if row_count > 0:
-        print(f"✔️ Backup {backup_table} contains {row_count} records — OK.")
+    if backup_table in table_names:
+        print(f"⚠️ Backup {backup_table} already exists. Skipping creation.")
     else:
-        print(f"❌ Table {backup_table} was created but is empty!")
+        print(f"🛠 Creating backup: {backup_table}")
+        conn.execute(f"CREATE TABLE {backup_table} AS SELECT * FROM epwa_detailed_flights")
+
+    try:
+        result = conn.execute(f"SELECT COUNT(*) FROM {backup_table}").fetchone()
+        row_count = result[0]
+
+        if row_count > 0:
+            print(f"✔️ Backup {backup_table} contains {row_count} records — OK.")
+        else:
+            print(f"❌ Table {backup_table} was created but is empty!")
+            sys.exit(1)
+
+    except Exception as e:
+        print(f"❌ Error during backup validation: {e}")
         sys.exit(1)
 
-except Exception as e:
-    print(f"❌ Error during backup validation: {e}")
-    sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/etl/drop_epwa_detailed_flights.py
+++ b/etl/drop_epwa_detailed_flights.py
@@ -1,19 +1,23 @@
 import duckdb
 from pathlib import Path
 
-# Path to the DuckDB database
-project_root = Path(__file__).resolve().parents[1]
-db_path = project_root / "db" / "epwa_traffic.duckdb"
 
-# Connection to the database
-conn = duckdb.connect(str(db_path))
+def main():
+    """Drop the epwa_detailed_flights table from DuckDB if it exists."""
+    project_root = Path(__file__).resolve().parents[1]
+    db_path = project_root / "db" / "epwa_traffic.duckdb"
 
-# Dropping the table if it exists
-try:
-    conn.execute("DROP TABLE IF EXISTS epwa_detailed_flights")
-    print("✔️ Table 'epwa_detailed_flights' has been dropped.")
-except Exception as e:
-    print(f"❌ Error while dropping the table: {e}")
-    raise
-finally:
-    conn.close()
+    conn = duckdb.connect(str(db_path))
+
+    try:
+        conn.execute("DROP TABLE IF EXISTS epwa_detailed_flights")
+        print("✔️ Table 'epwa_detailed_flights' has been dropped.")
+    except Exception as e:
+        print(f"❌ Error while dropping the table: {e}")
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/enrich_epwa_country_detailed_flights.py
+++ b/etl/enrich_epwa_country_detailed_flights.py
@@ -3,64 +3,66 @@ import duckdb
 from pathlib import Path
 from datetime import datetime
 
-# Initialize Spark session
-spark = SparkSession.builder.appName("EnrichArrivalCountry").getOrCreate()
 
-# Paths
-project_root = Path(__file__).resolve().parents[1]
-airports_path = project_root / "data" / "reference" / "airports.csv"
-db_path = project_root / "db" / "epwa_traffic.duckdb"
+def main():
+    """Enrich detailed flights with arrival country using airports reference."""
+    spark = SparkSession.builder.appName("EnrichArrivalCountry").getOrCreate()
 
-# Get current date
-today_str = datetime.utcnow().strftime('%Y-%m-%d')
+    project_root = Path(__file__).resolve().parents[1]
+    airports_path = project_root / "data" / "reference" / "airports.csv"
+    db_path = project_root / "db" / "epwa_traffic.duckdb"
 
-# Load only today's flights from DuckDB
-conn = duckdb.connect(str(db_path))
-df_flights = conn.execute(f"""
-    SELECT flight_number, operation_type, scheduled_datetime, arr_iata
-    FROM epwa_detailed_flights
-    WHERE flight_date = '{today_str}'
-""").df()
-df_flights = spark.createDataFrame(df_flights)
-df_flights.createOrReplaceTempView("flights")
+    today_str = datetime.utcnow().strftime("%Y-%m-%d")
 
-# Load airports.csv with IATA -> ISO country reference
-df_airports = spark.read.option("header", "true").csv(str(airports_path))
-df_airports.createOrReplaceTempView("airports")
+    conn = duckdb.connect(str(db_path))
+    df_flights = conn.execute(
+        f"""
+        SELECT flight_number, operation_type, scheduled_datetime, arr_iata
+        FROM epwa_detailed_flights
+        WHERE flight_date = '{today_str}'
+        """
+    ).df()
+    df_flights = spark.createDataFrame(df_flights)
+    df_flights.createOrReplaceTempView("flights")
 
-# Enrich flights with arrival_country
-query = """
-    SELECT
-        f.flight_number,
-        f.operation_type,
-        f.scheduled_datetime,
-        a.iso_country AS arrival_country
-    FROM flights f
-    LEFT JOIN airports a
-        ON f.arr_iata = a.iata_code
-    WHERE f.flight_number IS NOT NULL AND f.operation_type IS NOT NULL AND f.scheduled_datetime IS NOT NULL
-"""
+    df_airports = spark.read.option("header", "true").csv(str(airports_path))
+    df_airports.createOrReplaceTempView("airports")
 
-df_enriched = spark.sql(query)
+    query = """
+        SELECT
+            f.flight_number,
+            f.operation_type,
+            f.scheduled_datetime,
+            a.iso_country AS arrival_country
+        FROM flights f
+        LEFT JOIN airports a
+            ON f.arr_iata = a.iata_code
+        WHERE f.flight_number IS NOT NULL AND f.operation_type IS NOT NULL AND f.scheduled_datetime IS NOT NULL
+    """
 
-# Ensure column exists
-conn.execute("ALTER TABLE epwa_detailed_flights ADD COLUMN IF NOT EXISTS arrival_country VARCHAR;")
+    df_enriched = spark.sql(query)
 
-# Convert to Pandas and register in DuckDB
-df_enriched_pd = df_enriched.toPandas()
-conn.register("enriched", df_enriched_pd)
+    conn.execute("ALTER TABLE epwa_detailed_flights ADD COLUMN IF NOT EXISTS arrival_country VARCHAR;")
 
-# Update DuckDB with enriched data
-conn.execute("""
-    UPDATE epwa_detailed_flights AS main
-    SET arrival_country = sub.arrival_country
-    FROM enriched AS sub
-    WHERE
-        main.flight_number = sub.flight_number AND
-        main.operation_type = sub.operation_type AND
-        main.scheduled_datetime = sub.scheduled_datetime
-""")
+    df_enriched_pd = df_enriched.toPandas()
+    conn.register("enriched", df_enriched_pd)
 
-print("✅ arrival_country updated directly in epwa_detailed_flights.")
-conn.close()
-spark.stop()
+    conn.execute(
+        """
+        UPDATE epwa_detailed_flights AS main
+        SET arrival_country = sub.arrival_country
+        FROM enriched AS sub
+        WHERE
+            main.flight_number = sub.flight_number AND
+            main.operation_type = sub.operation_type AND
+            main.scheduled_datetime = sub.scheduled_datetime
+        """
+    )
+
+    print("✅ arrival_country updated directly in epwa_detailed_flights.")
+    conn.close()
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/extract.py
+++ b/etl/extract.py
@@ -34,19 +34,24 @@ def fetch_data(flight_direction):
     response.raise_for_status()
     return response.json()
 
-# === 📦 Fetching and Saving ===
-try:
-    arr_data = fetch_data('arrival')
-    dep_data = fetch_data('departure')
+def main():
+    """Fetch today's arrival and departure data and save it as JSON."""
+    try:
+        arr_data = fetch_data("arrival")
+        dep_data = fetch_data("departure")
 
-    with open(arr_file, 'w') as f:
-        json.dump(arr_data, f)
+        with open(arr_file, "w") as f:
+            json.dump(arr_data, f)
 
-    with open(dep_file, 'w') as f:
-        json.dump(dep_data, f)
+        with open(dep_file, "w") as f:
+            json.dump(dep_data, f)
 
-    print(f"[✔] Saved files: {arr_file.name}, {dep_file.name}")
+        print(f"[✔] Saved files: {arr_file.name}, {dep_file.name}")
 
-except Exception as e:
-    print(f"[✖] Error while fetching data: {e}")
-    raise
+    except Exception as e:
+        print(f"[✖] Error while fetching data: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/load_epwa_daily_traffic.py
+++ b/etl/load_epwa_daily_traffic.py
@@ -2,42 +2,51 @@ import duckdb
 import glob
 from pathlib import Path
 
-# 🔗 Paths
-project_root = Path(__file__).resolve().parents[1]
-db_path = project_root / 'db' / 'epwa_traffic.duckdb'
-csv_dirs = glob.glob(str(project_root / 'data' / 'processed' / 'daily_traffic' / 'daily_traffic_*_csv'))
 
-# 🔌 Connection to DuckDB
-conn = duckdb.connect(str(db_path))
-
-# 📅 Create table if it does not exist
-conn.execute('''
-    CREATE TABLE IF NOT EXISTS epwa_daily_traffic (
-        date DATE NOT NULL,
-        hour INTEGER NOT NULL,
-        operation_type VARCHAR NOT NULL,
-        flights_count INTEGER NOT NULL,
-        PRIMARY KEY (date, hour, operation_type)
+def main():
+    """Load aggregated daily traffic CSVs into DuckDB."""
+    project_root = Path(__file__).resolve().parents[1]
+    db_path = project_root / "db" / "epwa_traffic.duckdb"
+    csv_dirs = glob.glob(
+        str(project_root / "data" / "processed" / "daily_traffic" / "daily_traffic_*_csv")
     )
-''')
 
-# 📅 Load data from CSV files
-for dir_path in csv_dirs:
-    csv_files = glob.glob(f"{dir_path}/*.csv")
-    for file in csv_files:
-        print(f"🗕️ Loaded file: {file}")
-        conn.execute(f'''
-            INSERT INTO epwa_daily_traffic (date, hour, operation_type, flights_count)
-            SELECT
-                CAST(date AS DATE),
-                CAST(hour AS INTEGER),
-                CAST(operation_type AS VARCHAR),
-                CAST(flights_count AS INTEGER)
-            FROM read_csv_auto('{file}', HEADER=TRUE)
-            WHERE date IS NOT NULL AND hour IS NOT NULL AND operation_type IS NOT NULL
-            ON CONFLICT (date, hour, operation_type) DO UPDATE SET
-                flights_count = EXCLUDED.flights_count
-        ''')
+    conn = duckdb.connect(str(db_path))
 
-print("✅ Data loaded into epwa_daily_traffic.")
-conn.close()
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS epwa_daily_traffic (
+            date DATE NOT NULL,
+            hour INTEGER NOT NULL,
+            operation_type VARCHAR NOT NULL,
+            flights_count INTEGER NOT NULL,
+            PRIMARY KEY (date, hour, operation_type)
+        )
+        """
+    )
+
+    for dir_path in csv_dirs:
+        csv_files = glob.glob(f"{dir_path}/*.csv")
+        for file in csv_files:
+            print(f"🗕️ Loaded file: {file}")
+            conn.execute(
+                f"""
+                INSERT INTO epwa_daily_traffic (date, hour, operation_type, flights_count)
+                SELECT
+                    CAST(date AS DATE),
+                    CAST(hour AS INTEGER),
+                    CAST(operation_type AS VARCHAR),
+                    CAST(flights_count AS INTEGER)
+                FROM read_csv_auto('{file}', HEADER=TRUE)
+                WHERE date IS NOT NULL AND hour IS NOT NULL AND operation_type IS NOT NULL
+                ON CONFLICT (date, hour, operation_type) DO UPDATE SET
+                    flights_count = EXCLUDED.flights_count
+                """
+            )
+
+    print("✅ Data loaded into epwa_daily_traffic.")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/load_epwa_detailed_flights.py
+++ b/etl/load_epwa_detailed_flights.py
@@ -2,96 +2,105 @@ import duckdb
 import glob
 from pathlib import Path
 
-# 🔗 Paths
-project_root = Path(__file__).resolve().parents[1]
-db_path = project_root / 'db' / 'epwa_traffic.duckdb'
-csv_dirs = glob.glob(str(project_root / 'data' / 'processed' / 'detailed_flights' / 'details_*_csv'))
 
-# 🔌 Connection to DuckDB
-conn = duckdb.connect(str(db_path))
-
-# 🧱 Create table if it does not exist
-conn.execute("""
-    CREATE TABLE IF NOT EXISTS epwa_detailed_flights (
-        flight_date DATE,
-        flight_status VARCHAR,
-        dep_airport VARCHAR,
-        dep_iata VARCHAR,
-        dep_scheduled TIMESTAMP,
-        dep_actual TIMESTAMP,
-        dep_terminal VARCHAR,
-        dep_gate VARCHAR,
-        dep_delay INTEGER,
-        arr_airport VARCHAR,
-        arr_iata VARCHAR,
-        arr_scheduled TIMESTAMP,
-        arr_actual TIMESTAMP,
-        arr_terminal VARCHAR,
-        arr_gate VARCHAR,
-        arr_delay INTEGER,
-        airline_name VARCHAR,
-        flight_number VARCHAR NOT NULL,
-        operation_type VARCHAR NOT NULL,
-        scheduled_datetime TIMESTAMP NOT NULL,
-        arrival_country VARCHAR,
-        PRIMARY KEY (scheduled_datetime, flight_number, operation_type)
+def main():
+    """Load detailed flight CSVs into DuckDB."""
+    project_root = Path(__file__).resolve().parents[1]
+    db_path = project_root / "db" / "epwa_traffic.duckdb"
+    csv_dirs = glob.glob(
+        str(project_root / "data" / "processed" / "detailed_flights" / "details_*_csv")
     )
-""")
 
-# 📅 Load data from CSV files
-for dir_path in csv_dirs:
-    csv_files = glob.glob(f"{dir_path}/*.csv")
-    for file in csv_files:
-        print(f"📅 Loading file: {file}")
-        conn.execute(f"""
-            INSERT INTO epwa_detailed_flights (
-                flight_date, flight_status, dep_airport, dep_iata,
-                dep_scheduled, dep_actual, dep_terminal, dep_gate, dep_delay,
-                arr_airport, arr_iata, arr_scheduled, arr_actual, arr_terminal, arr_gate, arr_delay,
-                airline_name, flight_number, operation_type, scheduled_datetime
+    conn = duckdb.connect(str(db_path))
+
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS epwa_detailed_flights (
+            flight_date DATE,
+            flight_status VARCHAR,
+            dep_airport VARCHAR,
+            dep_iata VARCHAR,
+            dep_scheduled TIMESTAMP,
+            dep_actual TIMESTAMP,
+            dep_terminal VARCHAR,
+            dep_gate VARCHAR,
+            dep_delay INTEGER,
+            arr_airport VARCHAR,
+            arr_iata VARCHAR,
+            arr_scheduled TIMESTAMP,
+            arr_actual TIMESTAMP,
+            arr_terminal VARCHAR,
+            arr_gate VARCHAR,
+            arr_delay INTEGER,
+            airline_name VARCHAR,
+            flight_number VARCHAR NOT NULL,
+            operation_type VARCHAR NOT NULL,
+            scheduled_datetime TIMESTAMP NOT NULL,
+            arrival_country VARCHAR,
+            PRIMARY KEY (scheduled_datetime, flight_number, operation_type)
+        )
+        """
+    )
+
+    for dir_path in csv_dirs:
+        csv_files = glob.glob(f"{dir_path}/*.csv")
+        for file in csv_files:
+            print(f"📅 Loading file: {file}")
+            conn.execute(
+                f"""
+                INSERT INTO epwa_detailed_flights (
+                    flight_date, flight_status, dep_airport, dep_iata,
+                    dep_scheduled, dep_actual, dep_terminal, dep_gate, dep_delay,
+                    arr_airport, arr_iata, arr_scheduled, arr_actual, arr_terminal, arr_gate, arr_delay,
+                    airline_name, flight_number, operation_type, scheduled_datetime
+                )
+                SELECT
+                    CAST(flight_date AS DATE),
+                    flight_status,
+                    dep_airport,
+                    dep_iata,
+                    CAST(dep_scheduled AS TIMESTAMP),
+                    CAST(dep_actual AS TIMESTAMP),
+                    dep_terminal,
+                    dep_gate,
+                    CAST(dep_delay AS INTEGER),
+                    arr_airport,
+                    arr_iata,
+                    CAST(arr_scheduled AS TIMESTAMP),
+                    CAST(arr_actual AS TIMESTAMP),
+                    arr_terminal,
+                    arr_gate,
+                    CAST(arr_delay AS INTEGER),
+                    airline_name,
+                    flight_number,
+                    operation_type,
+                    CAST(scheduled_datetime AS TIMESTAMP)
+                FROM read_csv_auto('{file}', HEADER=TRUE)
+                WHERE flight_number IS NOT NULL AND operation_type IS NOT NULL AND scheduled_datetime IS NOT NULL
+                ON CONFLICT(scheduled_datetime, flight_number, operation_type) DO UPDATE SET
+                    flight_date=EXCLUDED.flight_date,
+                    flight_status=EXCLUDED.flight_status,
+                    dep_airport=EXCLUDED.dep_airport,
+                    dep_iata=EXCLUDED.dep_iata,
+                    dep_scheduled=EXCLUDED.dep_scheduled,
+                    dep_actual=EXCLUDED.dep_actual,
+                    dep_terminal=EXCLUDED.dep_terminal,
+                    dep_gate=EXCLUDED.dep_gate,
+                    dep_delay=EXCLUDED.dep_delay,
+                    arr_airport=EXCLUDED.arr_airport,
+                    arr_iata=EXCLUDED.arr_iata,
+                    arr_scheduled=EXCLUDED.arr_scheduled,
+                    arr_actual=EXCLUDED.arr_actual,
+                    arr_terminal=EXCLUDED.arr_terminal,
+                    arr_gate=EXCLUDED.arr_gate,
+                    arr_delay=EXCLUDED.arr_delay,
+                    airline_name=EXCLUDED.airline_name
+                """
             )
-            SELECT
-                CAST(flight_date AS DATE),
-                flight_status,
-                dep_airport,
-                dep_iata,
-                CAST(dep_scheduled AS TIMESTAMP),
-                CAST(dep_actual AS TIMESTAMP),
-                dep_terminal,
-                dep_gate,
-                CAST(dep_delay AS INTEGER),
-                arr_airport,
-                arr_iata,
-                CAST(arr_scheduled AS TIMESTAMP),
-                CAST(arr_actual AS TIMESTAMP),
-                arr_terminal,
-                arr_gate,
-                CAST(arr_delay AS INTEGER),
-                airline_name,
-                flight_number,
-                operation_type,
-                CAST(scheduled_datetime AS TIMESTAMP)
-            FROM read_csv_auto('{file}', HEADER=TRUE)
-            WHERE flight_number IS NOT NULL AND operation_type IS NOT NULL AND scheduled_datetime IS NOT NULL
-            ON CONFLICT(scheduled_datetime, flight_number, operation_type) DO UPDATE SET
-                flight_date=EXCLUDED.flight_date,
-                flight_status=EXCLUDED.flight_status,
-                dep_airport=EXCLUDED.dep_airport,
-                dep_iata=EXCLUDED.dep_iata,
-                dep_scheduled=EXCLUDED.dep_scheduled,
-                dep_actual=EXCLUDED.dep_actual,
-                dep_terminal=EXCLUDED.dep_terminal,
-                dep_gate=EXCLUDED.dep_gate,
-                dep_delay=EXCLUDED.dep_delay,
-                arr_airport=EXCLUDED.arr_airport,
-                arr_iata=EXCLUDED.arr_iata,
-                arr_scheduled=EXCLUDED.arr_scheduled,
-                arr_actual=EXCLUDED.arr_actual,
-                arr_terminal=EXCLUDED.arr_terminal,
-                arr_gate=EXCLUDED.arr_gate,
-                arr_delay=EXCLUDED.arr_delay,
-                airline_name=EXCLUDED.airline_name
-        """)
 
-print("✅ Data loaded into epwa_detailed_flights.")
-conn.close()
+    print("✅ Data loaded into epwa_detailed_flights.")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/transform_daily_traffic.py
+++ b/etl/transform_daily_traffic.py
@@ -2,57 +2,55 @@ from pyspark.sql import SparkSession
 from pathlib import Path
 from datetime import datetime
 
-# Initialize Spark session
-spark = SparkSession.builder.appName("FlightDataDailySQL").getOrCreate()
 
-# Paths
-project_root = Path(__file__).resolve().parents[1]
-raw_dir = project_root / "data" / "raw"
-daily_dir = project_root / "data" / "processed" / "daily_traffic"
-daily_dir.mkdir(parents=True, exist_ok=True)
+def main():
+    """Aggregate arrival and departure traffic counts by hour."""
+    spark = SparkSession.builder.appName("FlightDataDailySQL").getOrCreate()
 
-today_str = datetime.utcnow().strftime('%Y-%m-%d')
-dep_file = raw_dir / f"flights_dep_{today_str}.json"
-arr_file = raw_dir / f"flights_arr_{today_str}.json"
+    project_root = Path(__file__).resolve().parents[1]
+    raw_dir = project_root / "data" / "raw"
+    daily_dir = project_root / "data" / "processed" / "daily_traffic"
+    daily_dir.mkdir(parents=True, exist_ok=True)
 
-# Load JSON and create temporary views
-dep_df_raw = spark.read.option("multiline", "true").json(str(dep_file))
-dep_df_raw.selectExpr("explode(data) as flight_data").createOrReplaceTempView("dep_flights")
+    today_str = datetime.utcnow().strftime("%Y-%m-%d")
+    dep_file = raw_dir / f"flights_dep_{today_str}.json"
+    arr_file = raw_dir / f"flights_arr_{today_str}.json"
 
-arr_df_raw = spark.read.option("multiline", "true").json(str(arr_file))
-arr_df_raw.selectExpr("explode(data) as flight_data").createOrReplaceTempView("arr_flights")
+    dep_df_raw = spark.read.option("multiline", "true").json(str(dep_file))
+    dep_df_raw.selectExpr("explode(data) as flight_data").createOrReplaceTempView("dep_flights")
 
-# SQL to aggregate departure data by date and hour
-dep_sql = """
-    SELECT
-        to_date(flight_data.departure.scheduled) AS date,
-        hour(flight_data.departure.scheduled) AS hour,
-        COUNT(*) AS flights_count,
-        'departure' AS operation_type
-    FROM dep_flights
-    WHERE flight_data.departure.scheduled IS NOT NULL
-    GROUP BY to_date(flight_data.departure.scheduled), hour(flight_data.departure.scheduled)
+    arr_df_raw = spark.read.option("multiline", "true").json(str(arr_file))
+    arr_df_raw.selectExpr("explode(data) as flight_data").createOrReplaceTempView("arr_flights")
+
+    dep_sql = """
+        SELECT
+            to_date(flight_data.departure.scheduled) AS date,
+            hour(flight_data.departure.scheduled) AS hour,
+            COUNT(*) AS flights_count,
+            'departure' AS operation_type
+        FROM dep_flights
+        WHERE flight_data.departure.scheduled IS NOT NULL
+        GROUP BY to_date(flight_data.departure.scheduled), hour(flight_data.departure.scheduled)
 """
-
-# SQL to aggregate arrival data by date and hour
-arr_sql = """
-    SELECT
-        to_date(flight_data.arrival.scheduled) AS date,
-        hour(flight_data.arrival.scheduled) AS hour,
-        COUNT(*) AS flights_count,
-        'arrival' AS operation_type
-    FROM arr_flights
-    WHERE flight_data.arrival.scheduled IS NOT NULL
-    GROUP BY to_date(flight_data.arrival.scheduled), hour(flight_data.arrival.scheduled)
+    arr_sql = """
+        SELECT
+            to_date(flight_data.arrival.scheduled) AS date,
+            hour(flight_data.arrival.scheduled) AS hour,
+            COUNT(*) AS flights_count,
+            'arrival' AS operation_type
+        FROM arr_flights
+        WHERE flight_data.arrival.scheduled IS NOT NULL
+        GROUP BY to_date(flight_data.arrival.scheduled), hour(flight_data.arrival.scheduled)
 """
+    dep_df = spark.sql(dep_sql)
+    arr_df = spark.sql(arr_sql)
 
-# Execute SQL queries
-dep_df = spark.sql(dep_sql)
-arr_df = spark.sql(arr_sql)
+    final_df = dep_df.union(arr_df)
+    output_path = str(daily_dir / f"daily_traffic_{today_str}_csv")
+    final_df.coalesce(1).write.mode("overwrite").csv(output_path, header=True)
 
-# Combine and save to CSV
-final_df = dep_df.union(arr_df)
-output_path = str(daily_dir / f"daily_traffic_{today_str}_csv")
-final_df.coalesce(1).write.mode('overwrite').csv(output_path, header=True)
+    spark.stop()
 
-spark.stop()
+
+if __name__ == "__main__":
+    main()

--- a/etl/transform_detailed_scheduled_date.py
+++ b/etl/transform_detailed_scheduled_date.py
@@ -3,90 +3,90 @@ from pyspark.sql.functions import explode
 from pathlib import Path
 from datetime import datetime
 
-# Initialize Spark session
-spark = SparkSession.builder.appName("FlightDataDetailsSQL").getOrCreate()
 
-# Paths
-project_root = Path(__file__).resolve().parents[1]
-raw_dir = project_root / "data" / "raw"
-details_dir = project_root / "data" / "processed" / "detailed_flights"
-details_dir.mkdir(parents=True, exist_ok=True)
+def main():
+    """Transform raw arrival and departure JSON into a detailed CSV file."""
+    spark = SparkSession.builder.appName("FlightDataDetailsSQL").getOrCreate()
 
-today_str = datetime.utcnow().strftime('%Y-%m-%d')
-dep_file = raw_dir / f"flights_dep_{today_str}.json"
-arr_file = raw_dir / f"flights_arr_{today_str}.json"
+    project_root = Path(__file__).resolve().parents[1]
+    raw_dir = project_root / "data" / "raw"
+    details_dir = project_root / "data" / "processed" / "detailed_flights"
+    details_dir.mkdir(parents=True, exist_ok=True)
 
-# Load JSON and register exploded views
-dep_df_raw = spark.read.option("multiline", "true").json(str(dep_file))
-dep_df = dep_df_raw.select(explode("data").alias("flight_data"))
-dep_df.createOrReplaceTempView("dep_flights")
+    today_str = datetime.utcnow().strftime("%Y-%m-%d")
+    dep_file = raw_dir / f"flights_dep_{today_str}.json"
+    arr_file = raw_dir / f"flights_arr_{today_str}.json"
 
-arr_df_raw = spark.read.option("multiline", "true").json(str(arr_file))
-arr_df = arr_df_raw.select(explode("data").alias("flight_data"))
-arr_df.createOrReplaceTempView("arr_flights")
+    dep_df_raw = spark.read.option("multiline", "true").json(str(dep_file))
+    dep_df = dep_df_raw.select(explode("data").alias("flight_data"))
+    dep_df.createOrReplaceTempView("dep_flights")
 
-# SQL to extract relevant fields from departure
-dep_sql = """
-    SELECT
-        flight_data.flight_date AS flight_date,
-        flight_data.flight_status AS flight_status,
-        flight_data.departure.airport AS dep_airport,
-        flight_data.departure.iata AS dep_iata,
-        flight_data.departure.scheduled AS dep_scheduled,
-        flight_data.departure.actual AS dep_actual,
-        flight_data.departure.terminal AS dep_terminal,
-        flight_data.departure.gate AS dep_gate,
-        flight_data.departure.delay AS dep_delay,
-        flight_data.arrival.airport AS arr_airport,
-        flight_data.arrival.iata AS arr_iata,
-        flight_data.arrival.scheduled AS arr_scheduled,
-        flight_data.arrival.actual AS arr_actual,
-        flight_data.arrival.terminal AS arr_terminal,
-        flight_data.arrival.gate AS arr_gate,
-        flight_data.arrival.delay AS arr_delay,
-        flight_data.airline.name AS airline_name,
-        flight_data.flight.number AS flight_number,
-        'departure' AS operation_type,
-        flight_data.departure.scheduled AS scheduled_datetime
-    FROM dep_flights
-"""
+    arr_df_raw = spark.read.option("multiline", "true").json(str(arr_file))
+    arr_df = arr_df_raw.select(explode("data").alias("flight_data"))
+    arr_df.createOrReplaceTempView("arr_flights")
 
-# SQL to extract relevant fields from arrival
-arr_sql = """
-    SELECT
-        flight_data.flight_date AS flight_date,
-        flight_data.flight_status AS flight_status,
-        flight_data.departure.airport AS dep_airport,
-        flight_data.departure.iata AS dep_iata,
-        flight_data.departure.scheduled AS dep_scheduled,
-        flight_data.departure.actual AS dep_actual,
-        flight_data.departure.terminal AS dep_terminal,
-        flight_data.departure.gate AS dep_gate,
-        flight_data.departure.delay AS dep_delay,
-        flight_data.arrival.airport AS arr_airport,
-        flight_data.arrival.iata AS arr_iata,
-        flight_data.arrival.scheduled AS arr_scheduled,
-        flight_data.arrival.actual AS arr_actual,
-        flight_data.arrival.terminal AS arr_terminal,
-        flight_data.arrival.gate AS arr_gate,
-        flight_data.arrival.delay AS arr_delay,
-        flight_data.airline.name AS airline_name,
-        flight_data.flight.number AS flight_number,
-        'arrival' AS operation_type,
-        flight_data.arrival.scheduled AS scheduled_datetime
-    FROM arr_flights
-"""
+    dep_sql = """
+        SELECT
+            flight_data.flight_date AS flight_date,
+            flight_data.flight_status AS flight_status,
+            flight_data.departure.airport AS dep_airport,
+            flight_data.departure.iata AS dep_iata,
+            flight_data.departure.scheduled AS dep_scheduled,
+            flight_data.departure.actual AS dep_actual,
+            flight_data.departure.terminal AS dep_terminal,
+            flight_data.departure.gate AS dep_gate,
+            flight_data.departure.delay AS dep_delay,
+            flight_data.arrival.airport AS arr_airport,
+            flight_data.arrival.iata AS arr_iata,
+            flight_data.arrival.scheduled AS arr_scheduled,
+            flight_data.arrival.actual AS arr_actual,
+            flight_data.arrival.terminal AS arr_terminal,
+            flight_data.arrival.gate AS arr_gate,
+            flight_data.arrival.delay AS arr_delay,
+            flight_data.airline.name AS airline_name,
+            flight_data.flight.number AS flight_number,
+            'departure' AS operation_type,
+            flight_data.departure.scheduled AS scheduled_datetime
+        FROM dep_flights
+    """
 
-# Execute SQL and combine
-dep_details = spark.sql(dep_sql)
-arr_details = spark.sql(arr_sql)
-detailed_df = dep_details.union(arr_details)
+    arr_sql = """
+        SELECT
+            flight_data.flight_date AS flight_date,
+            flight_data.flight_status AS flight_status,
+            flight_data.departure.airport AS dep_airport,
+            flight_data.departure.iata AS dep_iata,
+            flight_data.departure.scheduled AS dep_scheduled,
+            flight_data.departure.actual AS dep_actual,
+            flight_data.departure.terminal AS dep_terminal,
+            flight_data.departure.gate AS dep_gate,
+            flight_data.departure.delay AS dep_delay,
+            flight_data.arrival.airport AS arr_airport,
+            flight_data.arrival.iata AS arr_iata,
+            flight_data.arrival.scheduled AS arr_scheduled,
+            flight_data.arrival.actual AS arr_actual,
+            flight_data.arrival.terminal AS arr_terminal,
+            flight_data.arrival.gate AS arr_gate,
+            flight_data.arrival.delay AS arr_delay,
+            flight_data.airline.name AS airline_name,
+            flight_data.flight.number AS flight_number,
+            'arrival' AS operation_type,
+            flight_data.arrival.scheduled AS scheduled_datetime
+        FROM arr_flights
+    """
 
-# Filter out rows with null flight_number or scheduled_datetime
-detailed_df = detailed_df.filter("flight_number IS NOT NULL AND scheduled_datetime IS NOT NULL")
+    dep_details = spark.sql(dep_sql)
+    arr_details = spark.sql(arr_sql)
+    detailed_df = dep_details.union(arr_details)
+    detailed_df = detailed_df.filter(
+        "flight_number IS NOT NULL AND scheduled_datetime IS NOT NULL"
+    )
 
-# Save to CSV
-output_path = str(details_dir / f"details_{today_str}_csv")
-detailed_df.coalesce(1).write.mode("overwrite").csv(output_path, header=True)
+    output_path = str(details_dir / f"details_{today_str}_csv")
+    detailed_df.coalesce(1).write.mode("overwrite").csv(output_path, header=True)
 
-spark.stop()
+    spark.stop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define `main()` entrypoints in ETL scripts
- replace BashOperator tasks with PythonOperator tasks

## Testing
- `python -m py_compile airflow/dags/*.py etl/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad4bf088c832f82e5d49b523ebe2b