### PR TITLE
Add systemd services

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,12 @@ You can set up the entire environment automatically on a fresh Ubuntu machine.
    ```
    This script verifies the Airflow webserver is running and reachable.
 
-   To restart the webserver, run:
+   The installer configures the scheduler and webserver as systemd services.
+   To restart them, run:
    ```bash
-   ./restart_webserver.sh
+   sudo systemctl restart airflow-webserver
+   sudo systemctl restart airflow-scheduler
    ```
-   The script assumes the project resides in `/home/airflow/epwa-flight-etl`
-   and starts the webserver on port `8080` in the background, writing logs to
-   `airflow/webserver.log`.
 
 ---
 


### PR DESCRIPTION
## Summary
- run Airflow webserver and scheduler with systemd units during install
- document how to restart services

## Testing
- `bash -n install_and_start.sh`
- `bash -n restart_webserver.sh`
- `bash -n check_airflow.sh`
- `bash -n update_project.sh`
- `bash -n scripts/update_dags.sh`
- `python -m py_compile $(find etl -name '*.py')`
- `python -m py_compile $(find airflow -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684afef33b9c832fbf13c168736ea41e